### PR TITLE
Added new "scheduled_time_at_destination" parameter to see arrival time as per timetable

### DIFF
--- a/custom_components/nationalrailuk/client.py
+++ b/custom_components/nationalrailuk/client.py
@@ -178,7 +178,7 @@ class NationalRailClient:
                     if delay > 9 and not perturbation:
                         perturbation = True
                 arrival_dest.append(
-                    {"name": dest["locationName"], "time_at_destination": arrival_time}
+                    {"name": dest["locationName"], "time_at_destination": arrival_time, "scheduled_time_at_destination": expected_arrival}
                 )
 
             train["scheduled"] = time


### PR DESCRIPTION
Added a new "scheduled_time_at_destination" parameter which can be used to show what time the train was due to arrive at the destination as per the timetable. This allows you to then use this parameter in a card to show scheduled time of arrival vs estimated time of arrival (similar to scheduled and estimated times of departure).