### PR TITLE
Added train length to sensor for each service.

### DIFF
--- a/custom_components/nationalrailuk/client.py
+++ b/custom_components/nationalrailuk/client.py
@@ -202,6 +202,7 @@ class NationalRailClient:
             train["terminus"] = terminus
             train["destinations"] = arrival_dest
             train["platform"] = service["platform"]
+            train["length"] = service["length"]
             train["perturbation"] = perturbation
 
             status["trains"].append(train)

--- a/custom_components/nationalrailuk/sensor.py
+++ b/custom_components/nationalrailuk/sensor.py
@@ -119,6 +119,7 @@ class NationalRailScheduleCoordinator(DataUpdateCoordinator):
             data["destinations"] = None
             data["terminus"] = None
             data["platform"] = None
+            data["length"] = None
             data["perturbations"] = False
 
             for each in data["trains"]:
@@ -141,6 +142,7 @@ class NationalRailScheduleCoordinator(DataUpdateCoordinator):
                     data["destinations"] = each["destinations"]
                     data["terminus"] = each["terminus"]
                     data["platform"] = each["platform"]
+                    data["length"] = each["length"]
 
                 data["perturbations"] = data["perturbations"] or each["perturbation"]
 


### PR DESCRIPTION
This modification seemed trivial - and having dumped the raw data, I see that train length (number of carriages) is at the same level in the data as platform. So I cloned the platform entry and converted to "length" in client.py and sensor.py

It seems to work correctly testing on my local line. 

This is useful information as our services have 4 car, 8 car and 12 car services which can be a hint as to how crowded they'll be.

I'm passing this patch back to you as being simple but of possible interest to others.

It's a purely additive change so it should not cause regression problems.