### PR TITLE
Update sensor.py to include device class and corrects attribution

### DIFF
--- a/custom_components/nationalrailuk/sensor.py
+++ b/custom_components/nationalrailuk/sensor.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
     DataUpdateCoordinator,
 )
-
+from homeassistant.components.sensor import SensorDeviceClass
 from .client import NationalRailClient
 from .const import (
     CONF_DESTINATIONS,
@@ -163,7 +163,8 @@ class NationalRailSchedule(CoordinatorEntity):
 
     """
 
-    attribution = "This uses National Rail Darwin Data Feeds"
+    _attr_attribution = "Data from National Rail Darwin Feeds"
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
 
     def __init__(self, coordinator):
         """Pass coordinator to CoordinatorEntity."""


### PR DESCRIPTION
Sorry for the unnecessary issue!

I realised the issue is just that HA is treating the timestamp as a string.
This sets the device class
It also corrects the attribution attr